### PR TITLE
PGN move parsing

### DIFF
--- a/Sage.xcodeproj/project.pbxproj
+++ b/Sage.xcodeproj/project.pbxproj
@@ -77,6 +77,13 @@
 		52E89C631CF53E1A0071AE69 /* InternalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E89C611CF53E1A0071AE69 /* InternalTypes.swift */; };
 		52E89C641CF53E1A0071AE69 /* InternalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E89C611CF53E1A0071AE69 /* InternalTypes.swift */; };
 		52E89C651CF53E1A0071AE69 /* InternalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E89C611CF53E1A0071AE69 /* InternalTypes.swift */; };
+		A365274F1DA7DD7900242747 /* PGNParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A365274D1DA7DC5B00242747 /* PGNParsingTests.swift */; };
+		A36527501DA7DD7900242747 /* PGNParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A365274D1DA7DC5B00242747 /* PGNParsingTests.swift */; };
+		A36527511DA7DD7A00242747 /* PGNParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A365274D1DA7DC5B00242747 /* PGNParsingTests.swift */; };
+		A3909E021DB802B600AE1E3B /* PGNMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3909E011DB802B600AE1E3B /* PGNMove.swift */; };
+		A3909E031DB802B600AE1E3B /* PGNMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3909E011DB802B600AE1E3B /* PGNMove.swift */; };
+		A3909E041DB802B600AE1E3B /* PGNMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3909E011DB802B600AE1E3B /* PGNMove.swift */; };
+		A3909E051DB802B600AE1E3B /* PGNMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3909E011DB802B600AE1E3B /* PGNMove.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +142,8 @@
 		52D2BB131D277E5400C868E5 /* Sequence+Sage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Sequence+Sage.swift"; sourceTree = "<group>"; };
 		52DF64131D2555390016BA9D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		52E89C611CF53E1A0071AE69 /* InternalTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalTypes.swift; sourceTree = "<group>"; };
+		A365274D1DA7DC5B00242747 /* PGNParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PGNParsingTests.swift; path = SageTests/PGNParsingTests.swift; sourceTree = "<group>"; };
+		A3909E011DB802B600AE1E3B /* PGNMove.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PGNMove.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -197,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				524583B01D0DF2BB002311F3 /* SageTests.swift */,
+				A365274D1DA7DC5B00242747 /* PGNParsingTests.swift */,
 				524583A91D0DE7B9002311F3 /* Info.plist */,
 			);
 			path = Tests;
@@ -247,6 +257,7 @@
 				529514DE1D16224F00BB244D /* Variant.swift */,
 				529514D91D138B4100BB244D /* CastlingRights.swift */,
 				527ADC201D2AFBE400B16439 /* PGN.swift */,
+				A3909E011DB802B600AE1E3B /* PGNMove.swift */,
 				52D2BB131D277E5400C868E5 /* Sequence+Sage.swift */,
 				52E89C611CF53E1A0071AE69 /* InternalTypes.swift */,
 				521AF8EE1D5949FB009941A0 /* Tables.swift */,
@@ -600,6 +611,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A365274F1DA7DD7900242747 /* PGNParsingTests.swift in Sources */,
 				524583B21D0DF2E2002311F3 /* SageTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -610,6 +622,7 @@
 			files = (
 				529515061D19CFF500BB244D /* Square.swift in Sources */,
 				529514DA1D138B4100BB244D /* CastlingRights.swift in Sources */,
+				A3909E021DB802B600AE1E3B /* PGNMove.swift in Sources */,
 				521AF8EF1D5949FB009941A0 /* Tables.swift in Sources */,
 				52E89C621CF53E1A0071AE69 /* InternalTypes.swift in Sources */,
 				528C2E421CF3E7F500F7D2EC /* Move.swift in Sources */,
@@ -633,6 +646,7 @@
 			files = (
 				529515071D19CFF500BB244D /* Square.swift in Sources */,
 				529514DB1D138B4100BB244D /* CastlingRights.swift in Sources */,
+				A3909E031DB802B600AE1E3B /* PGNMove.swift in Sources */,
 				521AF8F01D5949FB009941A0 /* Tables.swift in Sources */,
 				52E89C631CF53E1A0071AE69 /* InternalTypes.swift in Sources */,
 				528C2E431CF3E7F500F7D2EC /* Move.swift in Sources */,
@@ -656,6 +670,7 @@
 			files = (
 				529515081D19CFF500BB244D /* Square.swift in Sources */,
 				529514DC1D138B4100BB244D /* CastlingRights.swift in Sources */,
+				A3909E041DB802B600AE1E3B /* PGNMove.swift in Sources */,
 				521AF8F11D5949FB009941A0 /* Tables.swift in Sources */,
 				52E89C641CF53E1A0071AE69 /* InternalTypes.swift in Sources */,
 				528C2E441CF3E7F500F7D2EC /* Move.swift in Sources */,
@@ -679,6 +694,7 @@
 			files = (
 				529515091D19CFF500BB244D /* Square.swift in Sources */,
 				529514DD1D138B4100BB244D /* CastlingRights.swift in Sources */,
+				A3909E051DB802B600AE1E3B /* PGNMove.swift in Sources */,
 				521AF8F21D5949FB009941A0 /* Tables.swift in Sources */,
 				52E89C651CF53E1A0071AE69 /* InternalTypes.swift in Sources */,
 				528C2E451CF3E7F500F7D2EC /* Move.swift in Sources */,
@@ -700,6 +716,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A36527501DA7DD7900242747 /* PGNParsingTests.swift in Sources */,
 				529514D71D137BB800BB244D /* SageTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -708,6 +725,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A36527511DA7DD7A00242747 /* PGNParsingTests.swift in Sources */,
 				529514D81D137BB900BB244D /* SageTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Game.swift
+++ b/Sources/Game.swift
@@ -946,6 +946,17 @@ public final class Game {
         try execute(move: move, promotion: ._queen)
     }
 
+
+	/// Executes `move`, updating the state for `self`
+	///
+	/// - parameter move: The move (in a string) to be parsed and executed
+	///
+	/// - throws: `ParseError` if `move` is invalid, or `ExecutionError` if it's illegal.
+	public func execute(move: PGNMove) throws {
+		let parsedMove = try PGNParser.parse(move: move, in: position)
+		try execute(move: parsedMove, promotion: { move.promotionPiece ?? ._queen })
+	}
+
     #else
 
     /// Executes `move`, updating the state for `self`.

--- a/Sources/Game.swift
+++ b/Sources/Game.swift
@@ -991,6 +991,16 @@ public final class Game {
         try execute(move: move, promotion: ._queen)
     }
 
+	/// Executes `move`, updating the state for `self`
+	///
+	/// - parameter move: The move (in a string) to be parsed and executed
+	///
+	/// - throws: `ParseError` if `move` is invalid, or `ExecutionError` if it's illegal.
+	public func execute(move move: PGNMove) throws {
+		let parsedMove = try PGNParser.parse(move: move, in: position)
+		try execute(move: parsedMove, promotion: { move.promotionPiece ?? ._queen })
+	}
+
     #endif
 
     /// Returns the last move on the move stack, if any.

--- a/Sources/PGNMove.swift
+++ b/Sources/PGNMove.swift
@@ -1,0 +1,173 @@
+//
+//  PGNMove.swift
+//  Sage
+//
+//  Created by Kajetan Dąbrowski on 19/10/2016.
+//  Copyright © 2016 Nikolai Vazquez. All rights reserved.
+//
+
+import Foundation
+
+public struct PGNMove: RawRepresentable, ExpressibleByStringLiteral {
+
+	public enum ParseError: Error {
+		case invalidMove(String)
+	}
+
+	public typealias RawValue = String
+	public typealias StringLiteralType = String
+	public typealias ExtendedGraphemeClusterLiteralType = String
+	public typealias UnicodeScalarLiteralType = String
+	public let rawValue: String
+
+	static private let pattern = "^(?:([NBRQK]?)([a-h]?)([1-8]?)(x?)([a-h])([1-8])((?:=[NBRQ])?)|(O-O)|(O-O-O))([+#]?)$"
+	static private let regex: NSRegularExpression! = try? NSRegularExpression(pattern: pattern, options: [])
+
+	var match: NSTextCheckingResult?
+
+	public init?(rawValue: String) {
+		self.rawValue = rawValue
+		parse()
+		if !isPossible { return nil }
+	}
+
+	public init(stringLiteral value: String) {
+		rawValue = value
+		parse()
+	}
+
+	public init(unicodeScalarLiteral value: String) {
+		rawValue = value
+		parse()
+	}
+
+	public init(extendedGraphemeClusterLiteral value: String) {
+		rawValue = value
+		parse()
+	}
+
+	mutating private func parse() {
+		let matches = PGNMove.regex.matches(in: self.rawValue, options: [], range: self.fullRange)
+		self.match = matches.filter { $0.range.length == self.fullRange.length }.first
+	}
+
+	var fullRange: NSRange {
+		return NSRange(location: 0, length: rawValue.characters.count)
+	}
+
+	public var isPossible: Bool {
+		return match != nil
+	}
+
+	public var isCapture: Bool {
+		return match!.rangeAt(4).length > 0
+	}
+
+	public var isPromotion: Bool {
+		return match!.rangeAt(7).length > 0
+	}
+
+	public var isCastle: Bool {
+		return isCastleKingside || isCastleQueenside
+	}
+
+	public var isCastleKingside: Bool {
+		return match!.rangeAt(8).length > 0
+	}
+
+	public var isCastleQueenside: Bool {
+		return match!.rangeAt(9).length > 0
+	}
+
+	public var isCheck: Bool {
+		return match!.rangeAt(10).length > 0
+	}
+
+	public var isCheckmate: Bool {
+		return stringAt(rangeIndex: 10) == "#"
+	}
+
+	public var piece: Piece.Kind {
+		guard let match = match else { fatalError() }
+		let range = match.rangeAt(1)
+		let letter = (rawValue as NSString).substring(with: range)
+		return PGNMove.pieceFor(letter: letter)
+	}
+
+	public var rank: Rank {
+		let rankSymbol = stringAt(rangeIndex: 6)
+		return Rank(rawValue: Int(rankSymbol)!)!
+	}
+
+	public var file: File {
+		return File(stringAt(rangeIndex: 5).characters.first!)!
+	}
+
+	public var sourceRank: Rank? {
+		let sourceRankSymbol = stringAt(rangeIndex: 3)
+		if sourceRankSymbol == "" { return nil }
+		return Rank(rawValue: Int(sourceRankSymbol)!)!
+	}
+
+	public var sourceFile: File? {
+		let sourceFileSymbol = stringAt(rangeIndex: 2)
+		if sourceFileSymbol == "" { return nil }
+		return File(sourceFileSymbol.characters.first!)!
+	}
+
+
+	public var promotionPiece: Piece.Kind? {
+		if !isPromotion { return nil }
+		return PGNMove.pieceFor(letter: String(stringAt(rangeIndex: 7).characters.last!))
+	}
+
+	private static func pieceFor(letter: String) -> Piece.Kind {
+		switch letter {
+		case "N":
+			return ._knight
+		case "B":
+			return ._bishop
+		case "K":
+			return ._king
+		case "Q":
+			return ._queen
+		case "R":
+			return ._rook
+		case "":
+			return ._pawn
+		default:
+			fatalError()
+		}
+	}
+
+	private func stringAt(rangeIndex: Int) -> String {
+		guard let match = match else { fatalError() }
+		let range = match.rangeAt(rangeIndex)
+		let substring = (rawValue as NSString).substring(with: range)
+		return substring
+	}
+}
+
+public struct PGNParser {
+	public static func parse(move: PGNMove, in position: Game.Position) throws -> Move {
+		if !move.isPossible { throw PGNMove.ParseError.invalidMove(move.rawValue) }
+		let colorToMove = position.playerTurn
+		if move.isCastleKingside { return Move(castle: colorToMove, direction: .right) }
+		if move.isCastleQueenside { return Move(castle: colorToMove, direction: .left) }
+
+		let piece = Piece(kind: move.piece, color: colorToMove)
+		let destinationSquare: Square = Square(file: move.file, rank: move.rank)
+		let game = try Game(position: position)
+		var possibleMoves = game.availableMoves().filter { return $0.end == destinationSquare }.filter { move -> Bool in
+			game.board.locations(for: piece).contains(where: { move.start.location == $0 })
+		}
+
+		if let sourceFile = move.sourceFile { possibleMoves = possibleMoves.filter { $0.start.file == sourceFile } }
+		if let sourceRank = move.sourceRank { possibleMoves = possibleMoves.filter { $0.start.rank == sourceRank } }
+
+
+		if possibleMoves.count != 1 { throw PGNMove.ParseError.invalidMove(move.rawValue) }
+		return possibleMoves.first!
+
+	}
+}

--- a/Sources/PGNMove.swift
+++ b/Sources/PGNMove.swift
@@ -8,8 +8,15 @@
 
 import Foundation
 
+#if swift(>=3)
+
+/// A PGN move representation in a string.
 public struct PGNMove: RawRepresentable, ExpressibleByStringLiteral {
 
+
+	/// PGN Move parsing error
+	///
+	/// - invalidMove: The move is invalid
 	public enum ParseError: Error {
 		case invalidMove(String)
 	}
@@ -23,7 +30,13 @@ public struct PGNMove: RawRepresentable, ExpressibleByStringLiteral {
 	static private let pattern = "^(?:([NBRQK]?)([a-h]?)([1-8]?)(x?)([a-h])([1-8])((?:=[NBRQ])?)|(O-O)|(O-O-O))([+#]?)$"
 	static private let regex: NSRegularExpression! = try? NSRegularExpression(pattern: pattern, options: [])
 
-	var match: NSTextCheckingResult?
+	private var match: NSTextCheckingResult?
+	private var unwrappedMatch: NSTextCheckingResult {
+		guard let unwrappedMatch = match else {
+			fatalError("PGNMove not possible. Check move.isPossible before checking other properties")
+		}
+		return unwrappedMatch
+	}
 
 	public init?(rawValue: String) {
 		self.rawValue = rawValue
@@ -31,97 +44,124 @@ public struct PGNMove: RawRepresentable, ExpressibleByStringLiteral {
 		if !isPossible { return nil }
 	}
 
-	public init(stringLiteral value: String) {
+	public init(stringLiteral value: StringLiteralType) {
 		rawValue = value
 		parse()
 	}
 
-	public init(unicodeScalarLiteral value: String) {
+	public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
 		rawValue = value
 		parse()
 	}
 
-	public init(extendedGraphemeClusterLiteral value: String) {
+	public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
 		rawValue = value
 		parse()
 	}
 
 	mutating private func parse() {
-		let matches = PGNMove.regex.matches(in: self.rawValue, options: [], range: self.fullRange)
-		self.match = matches.filter { $0.range.length == self.fullRange.length }.first
+		let matches = PGNMove.regex.matches(in: rawValue, options: [], range: fullRange)
+		match = matches.filter { $0.range.length == self.fullRange.length }.first
 	}
 
-	var fullRange: NSRange {
+	private var fullRange: NSRange {
 		return NSRange(location: 0, length: rawValue.characters.count)
 	}
 
+	/// Indicates whether the move is possible.
 	public var isPossible: Bool {
 		return match != nil
 	}
 
+	/// Indicated whether the pgn represents a capture
 	public var isCapture: Bool {
-		return match!.rangeAt(4).length > 0
+		return unwrappedMatch.rangeAt(4).length > 0
 	}
 
+	/// Indicates whether the move represents a promotion
 	public var isPromotion: Bool {
-		return match!.rangeAt(7).length > 0
+		return unwrappedMatch.rangeAt(7).length > 0
 	}
 
+	/// Indicates whether the move is castle
 	public var isCastle: Bool {
 		return isCastleKingside || isCastleQueenside
 	}
 
+	/// Indicates whether the move is castle kingside
 	public var isCastleKingside: Bool {
-		return match!.rangeAt(8).length > 0
+		return unwrappedMatch.rangeAt(8).length > 0
 	}
 
+	/// Indicates whether the move is castle queenside
 	public var isCastleQueenside: Bool {
-		return match!.rangeAt(9).length > 0
+		return unwrappedMatch.rangeAt(9).length > 0
 	}
 
+	/// Indicates whether the move represents a check
 	public var isCheck: Bool {
-		return match!.rangeAt(10).length > 0
+		return unwrappedMatch.rangeAt(10).length > 0
 	}
 
+	/// Indicates whether the move represents a checkmate
 	public var isCheckmate: Bool {
 		return stringAt(rangeIndex: 10) == "#"
 	}
 
+	/// A piece kind that is moved by the move
 	public var piece: Piece.Kind {
-		guard let match = match else { fatalError() }
-		let range = match.rangeAt(1)
-		let letter = (rawValue as NSString).substring(with: range)
-		return PGNMove.pieceFor(letter: letter)
+		let pieceLetter = stringAt(rangeIndex: 1)
+		guard let piece = PGNMove.pieceFor(letter: pieceLetter) else {
+			fatalError("Invalid piece")
+		}
+		return piece
 	}
 
+	/// The rank to move to
 	public var rank: Rank {
 		let rankSymbol = stringAt(rangeIndex: 6)
-		return Rank(rawValue: Int(rankSymbol)!)!
+		guard let raw = Int(rankSymbol), let rank = Rank(rawValue: raw) else { fatalError("Could not get rank") }
+		return rank
 	}
 
+	/// The file to move to
 	public var file: File {
-		return File(stringAt(rangeIndex: 5).characters.first!)!
+		guard let fileSymbol = stringAt(rangeIndex: 5).characters.first,
+			let file = File(fileSymbol) else { fatalError("Could not get file") }
+		return file
 	}
 
+	/// The rank to move from.
+	/// For example in the move 'Nf3' there is no source rank, since PGNMove is out of board context.
+	/// However, if you specify the move like 'N4d2' the move will represent the knight from the fourth rank.
 	public var sourceRank: Rank? {
 		let sourceRankSymbol = stringAt(rangeIndex: 3)
 		if sourceRankSymbol == "" { return nil }
-		return Rank(rawValue: Int(sourceRankSymbol)!)!
+		guard let sourceRankRaw = Int(sourceRankSymbol),
+			let sourceRank = Rank(rawValue: sourceRankRaw) else { fatalError("Could not get source rank") }
+		return sourceRank
 	}
 
+	/// The file to move from.
+	/// For example in the move 'Nf3' there is no source file, since PGNMove is out of board context.
+	/// However, if you specify the move like 'Nfd2' the move will represent the knight from the d file.
 	public var sourceFile: File? {
 		let sourceFileSymbol = stringAt(rangeIndex: 2)
 		if sourceFileSymbol == "" { return nil }
-		return File(sourceFileSymbol.characters.first!)!
+		guard let sourceFileRaw = sourceFileSymbol.characters.first,
+			let sourceFile = File(sourceFileRaw) else { fatalError("Could not get source file") }
+		return sourceFile
 	}
 
-
+	/// Represents a piece that the move wants to promote to
 	public var promotionPiece: Piece.Kind? {
 		if !isPromotion { return nil }
-		return PGNMove.pieceFor(letter: String(stringAt(rangeIndex: 7).characters.last!))
+		guard let pieceLetter = stringAt(rangeIndex: 7).characters.last,
+			let piece = PGNMove.pieceFor(letter: String(pieceLetter)) else { fatalError("Could not get promotion piece") }
+		return piece
 	}
 
-	private static func pieceFor(letter: String) -> Piece.Kind {
+	private static func pieceFor(letter: String) -> Piece.Kind? {
 		switch letter {
 		case "N":
 			return ._knight
@@ -136,7 +176,7 @@ public struct PGNMove: RawRepresentable, ExpressibleByStringLiteral {
 		case "":
 			return ._pawn
 		default:
-			fatalError()
+			return nil
 		}
 	}
 
@@ -149,6 +189,17 @@ public struct PGNMove: RawRepresentable, ExpressibleByStringLiteral {
 }
 
 public struct PGNParser {
+
+
+
+	/// Parses the move in context of the game position
+	///
+	/// - parameter move:     Move that needs to be parsed
+	/// - parameter position: position to parse in
+	///
+	/// - throws: Errors if move is invalid, or if it cannot be executed in this position, or if it's ambiguous.
+	///
+	/// - returns: Parsed move that can be applied to a game (containing source and destination squares)
 	public static func parse(move: PGNMove, in position: Game.Position) throws -> Move {
 		if !move.isPossible { throw PGNMove.ParseError.invalidMove(move.rawValue) }
 		let colorToMove = position.playerTurn
@@ -165,9 +216,222 @@ public struct PGNParser {
 		if let sourceFile = move.sourceFile { possibleMoves = possibleMoves.filter { $0.start.file == sourceFile } }
 		if let sourceRank = move.sourceRank { possibleMoves = possibleMoves.filter { $0.start.rank == sourceRank } }
 
+		if possibleMoves.count != 1 { throw PGNMove.ParseError.invalidMove(move.rawValue) }
+		return possibleMoves.first!
+	}
+}
+
+#else
+
+/// A PGN move representation in a string.
+public struct PGNMove: RawRepresentable, StringLiteralConvertible {
+
+
+	/// PGN Move parsing error
+	///
+	/// - invalidMove: The move is invalid
+	public enum ParseError: ErrorType {
+		case invalidMove(String)
+	}
+
+	public typealias RawValue = String
+	public typealias StringLiteralType = String
+	public typealias ExtendedGraphemeClusterLiteralType = String
+	public typealias UnicodeScalarLiteralType = String
+	public let rawValue: String
+
+	static private let pattern = "^(?:([NBRQK]?)([a-h]?)([1-8]?)(x?)([a-h])([1-8])((?:=[NBRQ])?)|(O-O)|(O-O-O))([+#]?)$"
+	static private let regex: NSRegularExpression! = try? NSRegularExpression(pattern: pattern, options: [])
+
+	private var match: NSTextCheckingResult?
+	private var unwrappedMatch: NSTextCheckingResult {
+		guard let unwrappedMatch = match else {
+			fatalError("PGNMove not possible. Check move.isPossible before checking other properties")
+		}
+		return unwrappedMatch
+	}
+
+	public init?(rawValue: String) {
+		self.rawValue = rawValue
+		parse()
+		if !isPossible { return nil }
+	}
+
+	public init(stringLiteral value: StringLiteralType) {
+		rawValue = value
+		parse()
+	}
+
+	public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+		rawValue = value
+		parse()
+	}
+
+	public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+		rawValue = value
+		parse()
+	}
+
+	mutating private func parse() {
+		let matches = PGNMove.regex.matchesInString(rawValue, options: [], range: fullRange)
+		match = matches.filter { $0.range.length == self.fullRange.length }.first
+	}
+
+	private var fullRange: NSRange {
+		return NSRange(location: 0, length: rawValue.characters.count)
+	}
+
+	/// Indicates whether the move is possible.
+	public var isPossible: Bool {
+		return match != nil
+	}
+
+	/// Indicated whether the pgn represents a capture
+	public var isCapture: Bool {
+		return unwrappedMatch.rangeAtIndex(4).length > 0
+	}
+
+	/// Indicates whether the move represents a promotion
+	public var isPromotion: Bool {
+		return unwrappedMatch.rangeAtIndex(7).length > 0
+	}
+
+	/// Indicates whether the move is castle
+	public var isCastle: Bool {
+		return isCastleKingside || isCastleQueenside
+	}
+
+	/// Indicates whether the move is castle kingside
+	public var isCastleKingside: Bool {
+		return unwrappedMatch.rangeAtIndex(8).length > 0
+	}
+
+	/// Indicates whether the move is castle queenside
+	public var isCastleQueenside: Bool {
+		return unwrappedMatch.rangeAtIndex(9).length > 0
+	}
+
+	/// Indicates whether the move represents a check
+	public var isCheck: Bool {
+		return unwrappedMatch.rangeAtIndex(10).length > 0
+	}
+
+	/// Indicates whether the move represents a checkmate
+	public var isCheckmate: Bool {
+		return stringAtRangeIndex(10) == "#"
+	}
+
+	/// A piece kind that is moved by the move
+	public var piece: Piece.Kind {
+		let pieceLetter = stringAtRangeIndex(1)
+		guard let piece = PGNMove.pieceForLetter(pieceLetter) else {
+			fatalError("Invalid piece")
+		}
+		return piece
+	}
+
+	/// The rank to move to
+	public var rank: Rank {
+		let rankSymbol = stringAtRangeIndex(6)
+		guard let raw = Int(rankSymbol), let rank = Rank(rawValue: raw) else { fatalError("Could not get rank") }
+		return rank
+	}
+
+	/// The file to move to
+	public var file: File {
+		guard let fileSymbol = stringAtRangeIndex(5).characters.first,
+			let file = File(fileSymbol) else { fatalError("Could not get file") }
+		return file
+	}
+
+	/// The rank to move from.
+	/// For example in the move 'Nf3' there is no source rank, since PGNMove is out of board context.
+	/// However, if you specify the move like 'N4d2' the move will represent the knight from the fourth rank.
+	public var sourceRank: Rank? {
+		let sourceRankSymbol = stringAtRangeIndex(3)
+		if sourceRankSymbol == "" { return nil }
+		guard let sourceRankRaw = Int(sourceRankSymbol),
+			let sourceRank = Rank(rawValue: sourceRankRaw) else { fatalError("Could not get source rank") }
+		return sourceRank
+	}
+
+	/// The file to move from.
+	/// For example in the move 'Nf3' there is no source file, since PGNMove is out of board context.
+	/// However, if you specify the move like 'Nfd2' the move will represent the knight from the d file.
+	public var sourceFile: File? {
+		let sourceFileSymbol = stringAtRangeIndex(2)
+		if sourceFileSymbol == "" { return nil }
+		guard let sourceFileRaw = sourceFileSymbol.characters.first,
+			let sourceFile = File(sourceFileRaw) else { fatalError("Could not get source file") }
+		return sourceFile
+	}
+
+	/// Represents a piece that the move wants to promote to
+	public var promotionPiece: Piece.Kind? {
+		if !isPromotion { return nil }
+		guard let pieceLetter = stringAtRangeIndex(7).characters.last,
+			let piece = PGNMove.pieceForLetter(String(pieceLetter)) else { fatalError("Could not get promotion piece") }
+		return piece
+	}
+
+	private static func pieceForLetter(letter: String) -> Piece.Kind? {
+		switch letter {
+		case "N":
+			return ._knight
+		case "B":
+			return ._bishop
+		case "K":
+			return ._king
+		case "Q":
+			return ._queen
+		case "R":
+			return ._rook
+		case "":
+			return ._pawn
+		default:
+			return nil
+		}
+	}
+
+	private func stringAtRangeIndex(rangeIndex: Int) -> String {
+		guard let match = match else { fatalError() }
+		let range = match.rangeAtIndex(rangeIndex)
+		let substring = (rawValue as NSString).substringWithRange(range)
+		return substring
+	}
+}
+
+public struct PGNParser {
+
+
+
+	/// Parses the move in context of the game position
+	///
+	/// - parameter move:     Move that needs to be parsed
+	/// - parameter position: position to parse in
+	///
+	/// - throws: Errors if move is invalid, or if it cannot be executed in this position, or if it's ambiguous.
+	///
+	/// - returns: Parsed move that can be applied to a game (containing source and destination squares)
+	public static func parse(move move: PGNMove, in position: Game.Position) throws -> Move {
+		if !move.isPossible { throw PGNMove.ParseError.invalidMove(move.rawValue) }
+		let colorToMove = position.playerTurn
+		if move.isCastleKingside { return Move(castle: colorToMove, direction: .Right) }
+		if move.isCastleQueenside { return Move(castle: colorToMove, direction: .Left) }
+
+		let piece = Piece(kind: move.piece, color: colorToMove)
+		let destinationSquare: Square = Square(file: move.file, rank: move.rank)
+		let game = try Game(position: position)
+		var possibleMoves = game.availableMoves().filter { return $0.end == destinationSquare }.filter { move -> Bool in
+			game.board.locations(for: piece).contains { move.start.location == $0 }
+		}
+
+		if let sourceFile = move.sourceFile { possibleMoves = possibleMoves.filter { $0.start.file == sourceFile } }
+		if let sourceRank = move.sourceRank { possibleMoves = possibleMoves.filter { $0.start.rank == sourceRank } }
 
 		if possibleMoves.count != 1 { throw PGNMove.ParseError.invalidMove(move.rawValue) }
 		return possibleMoves.first!
-
 	}
 }
+
+#endif

--- a/Tests/SageTests/PGNParsingTests.swift
+++ b/Tests/SageTests/PGNParsingTests.swift
@@ -1,0 +1,238 @@
+//
+//  PGNParsingTests.swift
+//  Sage
+//
+//  Created by Kajetan Dąbrowski on 07/10/2016.
+//  Copyright © 2016 Nikolai Vazquez. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Sage
+
+class PGNParsingTests: XCTestCase {
+
+	let moves: [PGNMove] = ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nge7", "O-O", "f6", "Qe2", "d5",
+	                       "b3", "Qd6", "Na3", "Be6", "Rb1", "O-O-O", "Bxd5", "Qxd5", "exd5", "Nf5",
+	                       "d6", "Nfd4", "d7+", "Kb8", "Qa6", "Re8", "d8=Q+", "Nxd8", "Qxa7+", "Kxa7",
+	                       "Bb2", "N8c6", "Rfc1", "Rd8", "Ra1", "Rd5", "Rf1", "Bxa3", "Nxd4", "e4",
+	                       "f4", "exf3", "Rxf3", "Rhd8", "d3", "R5d6", "Bxa3", "Nxd4", "Bxd6", "Rf8",
+	                       "Bxf8", "Nc6", "Rf5", "Bf7", "Bc5+", "Ka8", "Rd5", "Nd8", "Rxd8#"]
+
+	let fens: [String] = ["rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+	                      "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1",
+	                      "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2",
+	                      "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
+	                      "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+	                      "r1bqkbnr/pppp1ppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3",
+	                      "r1bqkb1r/ppppnppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4",
+	                      "r1bqkb1r/ppppnppp/2n5/4p3/2B1P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 5 4",
+	                      "r1bqkb1r/ppppn1pp/2n2p2/4p3/2B1P3/5N2/PPPP1PPP/RNBQ1RK1 w kq - 0 5",
+	                      "r1bqkb1r/ppppn1pp/2n2p2/4p3/2B1P3/5N2/PPPPQPPP/RNB2RK1 b kq - 1 5",
+	                      "r1bqkb1r/ppp1n1pp/2n2p2/3pp3/2B1P3/5N2/PPPPQPPP/RNB2RK1 w kq d6 0 6",
+	                      "r1bqkb1r/ppp1n1pp/2n2p2/3pp3/2B1P3/1P3N2/P1PPQPPP/RNB2RK1 b kq - 0 6",
+	                      "r1b1kb1r/ppp1n1pp/2nq1p2/3pp3/2B1P3/1P3N2/P1PPQPPP/RNB2RK1 w kq - 1 7",
+	                      "r1b1kb1r/ppp1n1pp/2nq1p2/3pp3/2B1P3/NP3N2/P1PPQPPP/R1B2RK1 b kq - 2 7",
+	                      "r3kb1r/ppp1n1pp/2nqbp2/3pp3/2B1P3/NP3N2/P1PPQPPP/R1B2RK1 w kq - 3 8",
+	                      "r3kb1r/ppp1n1pp/2nqbp2/3pp3/2B1P3/NP3N2/P1PPQPPP/1RB2RK1 b kq - 4 8",
+	                      "2kr1b1r/ppp1n1pp/2nqbp2/3pp3/2B1P3/NP3N2/P1PPQPPP/1RB2RK1 w - - 5 9",
+	                      "2kr1b1r/ppp1n1pp/2nqbp2/3Bp3/4P3/NP3N2/P1PPQPPP/1RB2RK1 b - - 0 9",
+	                      "2kr1b1r/ppp1n1pp/2n1bp2/3qp3/4P3/NP3N2/P1PPQPPP/1RB2RK1 w - - 0 10",
+	                      "2kr1b1r/ppp1n1pp/2n1bp2/3Pp3/8/NP3N2/P1PPQPPP/1RB2RK1 b - - 0 10",
+	                      "2kr1b1r/ppp3pp/2n1bp2/3Ppn2/8/NP3N2/P1PPQPPP/1RB2RK1 w - - 1 11",
+	                      "2kr1b1r/ppp3pp/2nPbp2/4pn2/8/NP3N2/P1PPQPPP/1RB2RK1 b - - 0 11",
+	                      "2kr1b1r/ppp3pp/2nPbp2/4p3/3n4/NP3N2/P1PPQPPP/1RB2RK1 w - - 1 12",
+	                      "2kr1b1r/pppP2pp/2n1bp2/4p3/3n4/NP3N2/P1PPQPPP/1RB2RK1 b - - 0 12",
+	                      "1k1r1b1r/pppP2pp/2n1bp2/4p3/3n4/NP3N2/P1PPQPPP/1RB2RK1 w - - 1 13",
+	                      "1k1r1b1r/pppP2pp/Q1n1bp2/4p3/3n4/NP3N2/P1PP1PPP/1RB2RK1 b - - 2 13",
+	                      "1k2rb1r/pppP2pp/Q1n1bp2/4p3/3n4/NP3N2/P1PP1PPP/1RB2RK1 w - - 3 14",
+	                      "1k1Qrb1r/ppp3pp/Q1n1bp2/4p3/3n4/NP3N2/P1PP1PPP/1RB2RK1 b - - 0 14",
+	                      "1k1nrb1r/ppp3pp/Q3bp2/4p3/3n4/NP3N2/P1PP1PPP/1RB2RK1 w - - 0 15",
+	                      "1k1nrb1r/Qpp3pp/4bp2/4p3/3n4/NP3N2/P1PP1PPP/1RB2RK1 b - - 0 15",
+	                      "3nrb1r/kpp3pp/4bp2/4p3/3n4/NP3N2/P1PP1PPP/1RB2RK1 w - - 0 16",
+	                      "3nrb1r/kpp3pp/4bp2/4p3/3n4/NP3N2/PBPP1PPP/1R3RK1 b - - 1 16",
+	                      "4rb1r/kpp3pp/2n1bp2/4p3/3n4/NP3N2/PBPP1PPP/1R3RK1 w - - 2 17",
+	                      "4rb1r/kpp3pp/2n1bp2/4p3/3n4/NP3N2/PBPP1PPP/1RR3K1 b - - 3 17",
+	                      "3r1b1r/kpp3pp/2n1bp2/4p3/3n4/NP3N2/PBPP1PPP/1RR3K1 w - - 4 18",
+	                      "3r1b1r/kpp3pp/2n1bp2/4p3/3n4/NP3N2/PBPP1PPP/R1R3K1 b - - 5 18",
+	                      "5b1r/kpp3pp/2n1bp2/3rp3/3n4/NP3N2/PBPP1PPP/R1R3K1 w - - 6 19",
+	                      "5b1r/kpp3pp/2n1bp2/3rp3/3n4/NP3N2/PBPP1PPP/R4RK1 b - - 7 19",
+	                      "7r/kpp3pp/2n1bp2/3rp3/3n4/bP3N2/PBPP1PPP/R4RK1 w - - 0 20",
+	                      "7r/kpp3pp/2n1bp2/3rp3/3N4/bP6/PBPP1PPP/R4RK1 b - - 0 20",
+	                      "7r/kpp3pp/2n1bp2/3r4/3Np3/bP6/PBPP1PPP/R4RK1 w - - 0 21",
+	                      "7r/kpp3pp/2n1bp2/3r4/3NpP2/bP6/PBPP2PP/R4RK1 b - f3 0 21",
+	                      "7r/kpp3pp/2n1bp2/3r4/3N4/bP3p2/PBPP2PP/R4RK1 w - - 0 22",
+	                      "7r/kpp3pp/2n1bp2/3r4/3N4/bP3R2/PBPP2PP/R5K1 b - - 0 22",
+	                      "3r4/kpp3pp/2n1bp2/3r4/3N4/bP3R2/PBPP2PP/R5K1 w - - 1 23",
+	                      "3r4/kpp3pp/2n1bp2/3r4/3N4/bP1P1R2/PBP3PP/R5K1 b - - 0 23",
+	                      "3r4/kpp3pp/2nrbp2/8/3N4/bP1P1R2/PBP3PP/R5K1 w - - 1 24",
+	                      "3r4/kpp3pp/2nrbp2/8/3N4/BP1P1R2/P1P3PP/R5K1 b - - 0 24",
+	                      "3r4/kpp3pp/3rbp2/8/3n4/BP1P1R2/P1P3PP/R5K1 w - - 0 25",
+	                      "3r4/kpp3pp/3Bbp2/8/3n4/1P1P1R2/P1P3PP/R5K1 b - - 0 25",
+	                      "5r2/kpp3pp/3Bbp2/8/3n4/1P1P1R2/P1P3PP/R5K1 w - - 1 26",
+	                      "5B2/kpp3pp/4bp2/8/3n4/1P1P1R2/P1P3PP/R5K1 b - - 0 26",
+	                      "5B2/kpp3pp/2n1bp2/8/8/1P1P1R2/P1P3PP/R5K1 w - - 1 27",
+	                      "5B2/kpp3pp/2n1bp2/5R2/8/1P1P4/P1P3PP/R5K1 b - - 2 27",
+	                      "5B2/kpp2bpp/2n2p2/5R2/8/1P1P4/P1P3PP/R5K1 w - - 3 28",
+	                      "8/kpp2bpp/2n2p2/2B2R2/8/1P1P4/P1P3PP/R5K1 b - - 4 28",
+	                      "k7/1pp2bpp/2n2p2/2B2R2/8/1P1P4/P1P3PP/R5K1 w - - 5 29",
+	                      "k7/1pp2bpp/2n2p2/2BR4/8/1P1P4/P1P3PP/R5K1 b - - 6 29",
+	                      "k2n4/1pp2bpp/5p2/2BR4/8/1P1P4/P1P3PP/R5K1 w - - 7 30",
+	                      "k2R4/1pp2bpp/5p2/2B5/8/1P1P4/P1P3PP/R5K1 b - - 0 30"]
+
+	func testGameParsingPGNStyleMoves() throws {
+		XCTAssertEqual(fens.count, moves.count + 1)
+	}
+
+	func testAllMovesInInitialPosition() {
+		let initialPosition = Game.Position()
+		let possibleMoves: [PGNMove] = ["a3", "a4", "b3", "b4", "Nf3", "e4", "e3", "d4", "Nc3", "Na3", "h3"]
+		let resultingMoves: [Move] = [Move(start: .a2, end: .a3),
+		                              Move(start: .a2, end: .a4),
+		                              Move(start: .b2, end: .b3),
+		                              Move(start: .b2, end: .b4),
+		                              Move(start: .g1, end: .f3),
+		                              Move(start: .e2, end: .e4),
+		                              Move(start: .e2, end: .e3),
+		                              Move(start: .d2, end: .d4),
+		                              Move(start: .b1, end: .c3),
+		                              Move(start: .b1, end: .a3),
+		                              Move(start: .h2, end: .h3)]
+		for i in 0..<possibleMoves.count {
+			try XCTAssertEqual(PGNParser.parse(move: possibleMoves[i], in: initialPosition), resultingMoves[i])
+		}
+	}
+
+	func testRookMovesParsing() {
+		let position = Game.Position(fen: "1kq5/7R/8/8/R2PR2R/8/8/4K2R w - - 0 1")!
+		XCTAssertEqual(try? PGNParser.parse(move: "Ra4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rb4+", in: position), Move(start: .a4, end: .b4))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rc4", in: position), Move(start: .a4, end: .c4))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rd4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Re4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rf4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rg4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Reg4", in: position), Move(start: .e4, end: .g4))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rhg4", in: position), Move(start: .h4, end: .g4))
+
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh8", in: position), Move(start: .h7, end: .h8))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh7", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh6", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh6", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rhh6", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "R7h6", in: position), Move(start: .h7, end: .h6))
+	}
+
+	func testGamePlaysCorrectly() {
+		for i in 0..<moves.count {
+			do {
+				let startFen = fens[i]
+				let expectedFen = fens[i+1]
+				let startPosition = Game.Position(fen: startFen)!
+				let moveString = moves[i]
+				let move = try PGNParser.parse(move: moveString, in: startPosition)
+				let game = try Game(position: startPosition)
+				try game.execute(move: move)
+				var fenElements = game.position.fen().components(separatedBy: " ")
+				fenElements.removeLast()
+				let finalFen = fenElements.joined(separator: " ")
+				var expectedFenElements = expectedFen.components(separatedBy: " ")
+				expectedFenElements.removeLast()
+				let finalExpectedFen = expectedFenElements.joined(separator: " ")
+				XCTAssertEqual(finalFen, finalExpectedFen)
+			} catch {
+				XCTFail(error.localizedDescription)
+			}
+		}
+	}
+
+	func testPGNValidMoves() {
+		let validMoves: [String] = ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nge7", "O-O", "f6", "Qe2", "d5",
+		                   "b3", "Qd6", "Na3", "Be6", "Rb1", "O-O-O", "Bxd5", "Qxd5", "exd5", "Nf5",
+		                   "d6", "Nfd4", "d7+", "Kb8", "Qa6", "Re8", "d8=Q+", "Nxd8", "Qxa7+", "Kxa7",
+		                   "Bb2", "N8c6", "Rfc1", "Rd8", "Ra1", "Rd5", "Rf1", "Bxa3", "Nxd4", "e4",
+		                   "f4", "exf3", "Rxf3", "Rhd8", "d3", "R5d6", "Bxa3", "Nxd4", "Bxd6", "Rf8",
+		                   "Bxf8", "Nc6", "Rf5", "Bf7", "Bc5+", "Ka8", "Rd5", "Nd8", "Rxd8#"]
+
+		let invalidMoves: [String] = ["r3gr34", "xihwr", "Ld4", "j3", "Rxf9", "😮"]
+		for move in validMoves {
+			XCTAssertNotNil(PGNMove(rawValue: move))
+			XCTAssertEqual(PGNMove(rawValue: move)?.isPossible, true)
+		}
+
+		for move in invalidMoves {
+			XCTAssertNil(PGNMove(rawValue: move))
+		}
+
+		let capture = PGNMove(rawValue: "Nxe6")
+		XCTAssertNotNil(capture)
+		XCTAssertTrue(capture!.isPossible)
+		XCTAssertTrue(capture!.isCapture)
+		XCTAssertFalse(capture!.isPromotion)
+		XCTAssertNil(capture!.promotionPiece)
+		XCTAssertFalse(capture!.isCheck)
+		XCTAssertFalse(capture!.isCheckmate)
+		XCTAssertEqual(capture!.piece, Piece.Kind._knight)
+		XCTAssertFalse(capture!.isCastle)
+		XCTAssertEqual(capture!.rank, Rank.six)
+		XCTAssertEqual(capture!.file, File.e)
+		XCTAssertEqual(capture!.sourceRank, nil)
+		XCTAssertEqual(capture!.sourceFile, nil)
+
+		let promotion: PGNMove = "d8=B#"
+		XCTAssertTrue(promotion.isPossible)
+		XCTAssertFalse(promotion.isCapture)
+		XCTAssertTrue(promotion.isPromotion)
+		XCTAssertEqual(promotion.promotionPiece, Piece.Kind._bishop)
+		XCTAssertTrue(promotion.isCheck)
+		XCTAssertTrue(promotion.isCheckmate)
+		XCTAssertEqual(promotion.piece, Piece.Kind._pawn)
+		XCTAssertFalse(promotion.isCastle)
+		XCTAssertEqual(promotion.rank, Rank.eight)
+		XCTAssertEqual(promotion.file, File.d)
+		XCTAssertEqual(promotion.sourceRank, nil)
+		XCTAssertEqual(promotion.sourceFile, nil)
+
+		let pawnCapture: PGNMove = "axb4"
+		XCTAssertTrue(pawnCapture.isPossible)
+		XCTAssertTrue(pawnCapture.isCapture)
+		XCTAssertFalse(pawnCapture.isPromotion)
+		XCTAssertNil(pawnCapture.promotionPiece)
+		XCTAssertFalse(pawnCapture.isCheck)
+		XCTAssertFalse(pawnCapture.isCheckmate)
+		XCTAssertEqual(pawnCapture.piece, Piece.Kind._pawn)
+		XCTAssertFalse(pawnCapture.isCastle)
+		XCTAssertEqual(pawnCapture.rank, Rank.four)
+		XCTAssertEqual(pawnCapture.file, File.b)
+		XCTAssertEqual(pawnCapture.sourceRank, nil)
+		XCTAssertEqual(pawnCapture.sourceFile, File.a)
+
+		XCTAssertTrue(PGNMove(rawValue: "O-O-O")!.isCastleQueenside)
+		XCTAssertFalse(PGNMove(rawValue: "O-O-O")!.isCastleKingside)
+		XCTAssertTrue(PGNMove(rawValue: "O-O-O")!.isCastle)
+		XCTAssertFalse(PGNMove(rawValue: "O-O-O")!.isCheck)
+
+		XCTAssertFalse(PGNMove(rawValue: "O-O+")!.isCastleQueenside)
+		XCTAssertTrue(PGNMove(rawValue: "O-O+")!.isCastleKingside)
+		XCTAssertTrue(PGNMove(rawValue: "O-O+")!.isCastle)
+		XCTAssertTrue(PGNMove(rawValue: "O-O+")!.isCheck)
+	}
+
+	func testParserShouldNotCrashOnInvalidMoves() {
+		let game = Game()
+		XCTAssertThrowsError(try game.execute(move: "aiuw"))
+		XCTAssertThrowsError(try game.execute(move: ""))
+		XCTAssertThrowsError(try game.execute(move: "a#"))
+		XCTAssertThrowsError(try game.execute(move: "a"))
+		XCTAssertThrowsError(try game.execute(move: "w"))
+		XCTAssertThrowsError(try game.execute(move: "!3"))
+		XCTAssertThrowsError(try game.execute(move: "ad"))
+		XCTAssertThrowsError(try game.execute(move: "aB"))
+		XCTAssertThrowsError(try game.execute(move: "B3"))
+		XCTAssertThrowsError(try game.execute(move: "x"))
+		XCTAssertThrowsError(try game.execute(move: "1"))
+		XCTAssertThrowsError(try game.execute(move: "🍣"))
+		XCTAssertThrowsError(try game.execute(move: "VASF234df89ayrsdfiuafiuawf"))
+	}
+}

--- a/Tests/SageTests/PGNParsingTests.swift
+++ b/Tests/SageTests/PGNParsingTests.swift
@@ -87,6 +87,7 @@ class PGNParsingTests: XCTestCase {
 	func testAllMovesInInitialPosition() {
 		let initialPosition = Game.Position()
 		let possibleMoves: [PGNMove] = ["a3", "a4", "b3", "b4", "Nf3", "e4", "e3", "d4", "Nc3", "Na3", "h3"]
+		#if swift(>=3)
 		let resultingMoves: [Move] = [Move(start: .a2, end: .a3),
 		                              Move(start: .a2, end: .a4),
 		                              Move(start: .b2, end: .b3),
@@ -98,10 +99,26 @@ class PGNParsingTests: XCTestCase {
 		                              Move(start: .b1, end: .c3),
 		                              Move(start: .b1, end: .a3),
 		                              Move(start: .h2, end: .h3)]
+		#else
+		let resultingMoves: [Move] = [Move(start: .A2, end: .A3),
+									  Move(start: .A2, end: .A4),
+									  Move(start: .B2, end: .B3),
+									  Move(start: .B2, end: .B4),
+									  Move(start: .G1, end: .F3),
+									  Move(start: .E2, end: .E4),
+									  Move(start: .E2, end: .E3),
+									  Move(start: .D2, end: .D4),
+									  Move(start: .B1, end: .C3),
+									  Move(start: .B1, end: .A3),
+									  Move(start: .H2, end: .H3)]
+
+		#endif
 		for i in 0..<possibleMoves.count {
 			try XCTAssertEqual(PGNParser.parse(move: possibleMoves[i], in: initialPosition), resultingMoves[i])
 		}
 	}
+
+	#if swift(>=3)
 
 	func testRookMovesParsing() {
 		let position = Game.Position(fen: "1kq5/7R/8/8/R2PR2R/8/8/4K2R w - - 0 1")!
@@ -124,6 +141,31 @@ class PGNParsingTests: XCTestCase {
 		XCTAssertEqual(try? PGNParser.parse(move: "R7h6", in: position), Move(start: .h7, end: .h6))
 	}
 
+	#else
+
+	func testRookMovesParsing() {
+		let position = Game.Position(fen: "1kq5/7R/8/8/R2PR2R/8/8/4K2R w - - 0 1")!
+		XCTAssertEqual(try? PGNParser.parse(move: "Ra4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rb4+", in: position), Move(start: .A4, end: .B4))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rc4", in: position), Move(start: .A4, end: .C4))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rd4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Re4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rf4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rg4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh4", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Reg4", in: position), Move(start: .E4, end: .G4))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rhg4", in: position), Move(start: .H4, end: .G4))
+
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh8", in: position), Move(start: .H7, end: .H8))
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh7", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh6", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rh6", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "Rhh6", in: position), nil)
+		XCTAssertEqual(try? PGNParser.parse(move: "R7h6", in: position), Move(start: .H7, end: .H6))
+	}
+
+	#endif
+
 	func testGamePlaysCorrectly() {
 		for i in 0..<moves.count {
 			do {
@@ -134,15 +176,25 @@ class PGNParsingTests: XCTestCase {
 				let move = try PGNParser.parse(move: moveString, in: startPosition)
 				let game = try Game(position: startPosition)
 				try game.execute(move: move)
+				#if swift(>=3)
 				var fenElements = game.position.fen().components(separatedBy: " ")
-				fenElements.removeLast()
+				_ = fenElements.removeLast()
 				let finalFen = fenElements.joined(separator: " ")
 				var expectedFenElements = expectedFen.components(separatedBy: " ")
-				expectedFenElements.removeLast()
+				_ = expectedFenElements.removeLast()
 				let finalExpectedFen = expectedFenElements.joined(separator: " ")
+				#else
+				var fenElements = game.position.fen().componentsSeparatedByString(" ")
+				_ = fenElements.removeLast()
+				let finalFen = fenElements.joinWithSeparator(" ")
+				var expectedFenElements = expectedFen.componentsSeparatedByString(" ")
+				_ = expectedFenElements.removeLast()
+				let finalExpectedFen = expectedFenElements.joinWithSeparator(" ")
+				#endif
+
 				XCTAssertEqual(finalFen, finalExpectedFen)
 			} catch {
-				XCTFail(error.localizedDescription)
+				XCTFail("\(error)")
 			}
 		}
 	}
@@ -175,8 +227,8 @@ class PGNParsingTests: XCTestCase {
 		XCTAssertFalse(capture!.isCheckmate)
 		XCTAssertEqual(capture!.piece, Piece.Kind._knight)
 		XCTAssertFalse(capture!.isCastle)
-		XCTAssertEqual(capture!.rank, Rank.six)
-		XCTAssertEqual(capture!.file, File.e)
+		XCTAssertEqual(capture!.rank, Rank(6))
+		XCTAssertEqual(capture!.file, File._e)
 		XCTAssertEqual(capture!.sourceRank, nil)
 		XCTAssertEqual(capture!.sourceFile, nil)
 
@@ -189,8 +241,8 @@ class PGNParsingTests: XCTestCase {
 		XCTAssertTrue(promotion.isCheckmate)
 		XCTAssertEqual(promotion.piece, Piece.Kind._pawn)
 		XCTAssertFalse(promotion.isCastle)
-		XCTAssertEqual(promotion.rank, Rank.eight)
-		XCTAssertEqual(promotion.file, File.d)
+		XCTAssertEqual(promotion.rank, Rank(8))
+		XCTAssertEqual(promotion.file, File._d)
 		XCTAssertEqual(promotion.sourceRank, nil)
 		XCTAssertEqual(promotion.sourceFile, nil)
 
@@ -203,10 +255,10 @@ class PGNParsingTests: XCTestCase {
 		XCTAssertFalse(pawnCapture.isCheckmate)
 		XCTAssertEqual(pawnCapture.piece, Piece.Kind._pawn)
 		XCTAssertFalse(pawnCapture.isCastle)
-		XCTAssertEqual(pawnCapture.rank, Rank.four)
-		XCTAssertEqual(pawnCapture.file, File.b)
+		XCTAssertEqual(pawnCapture.rank, Rank(4))
+		XCTAssertEqual(pawnCapture.file, File._b)
 		XCTAssertEqual(pawnCapture.sourceRank, nil)
-		XCTAssertEqual(pawnCapture.sourceFile, File.a)
+		XCTAssertEqual(pawnCapture.sourceFile, File._a)
 
 		XCTAssertTrue(PGNMove(rawValue: "O-O-O")!.isCastleQueenside)
 		XCTAssertFalse(PGNMove(rawValue: "O-O-O")!.isCastleKingside)
@@ -218,6 +270,8 @@ class PGNParsingTests: XCTestCase {
 		XCTAssertTrue(PGNMove(rawValue: "O-O+")!.isCastle)
 		XCTAssertTrue(PGNMove(rawValue: "O-O+")!.isCheck)
 	}
+
+	#if swift(>=3)
 
 	func testParserShouldNotCrashOnInvalidMoves() {
 		let game = Game()
@@ -235,4 +289,6 @@ class PGNParsingTests: XCTestCase {
 		XCTAssertThrowsError(try game.execute(move: "🍣"))
 		XCTAssertThrowsError(try game.execute(move: "VASF234df89ayrsdfiuafiuawf"))
 	}
+
+	#endif
 }


### PR DESCRIPTION
I've added PGNMove struct (representable by string) as well as parsing PGN Moves.

You can now use this API as this:
`
game.execute(move: "NF3")
game.execute(move: "O-O")
game.execute(move: "exd5")
game.execute(move: "d8=Q+")
`

Parsing is one way for now – you can only apply text moves to a game.
