### PR TITLE
Fixed issue in `Game` copying

### DIFF
--- a/Sources/Game.swift
+++ b/Sources/Game.swift
@@ -522,6 +522,7 @@ public final class Game {
         self.attackersToKing = game.attackersToKing
         self.halfmoves       = game.halfmoves
         self.fullmoves       = game.fullmoves
+        self.enPassantTarget = game.enPassantTarget
     }
 
     /// Creates a new chess game.


### PR DESCRIPTION
I don't know whether it is _deliberate_ for not adding the code `self.enPassantTarget = game.enPassantTarget`.
But not adding this line will cause the following issue:

Let's suppose a game A is in an "En Passant" state, that is, the next player who moves the piece can make an en passant move. Apparently, calling `myGame.isLegal(move: myEnPassantMove)` will return `true`. But if we call `myGame.copy().isLegal(move: myEnPassantMove)`, it will return `false` which is not act as "expected".

