### PR TITLE
Fixed a bug in `_redoMove()`

### DIFF
--- a/Sources/Game.swift
+++ b/Sources/Game.swift
@@ -425,7 +425,7 @@ public final class Game {
                                 rights: CastlingRights)]
 
     /// All of the undone moves in the game.
-    private var _undoHistory: [(move: Move, promotion: Piece.Kind?, kingAttackers: Bitboard)]
+    private var _undoHistory: [(move: Move, promotion: Piece.Kind?, enPassantTarget: Square?, kingAttackers: Bitboard)]
 
     /// The game's board.
     public private(set) var board: Board
@@ -1040,7 +1040,7 @@ public final class Game {
         if let capture = capture {
             board[capture][captureSquare] = true
         }
-        _undoHistory.append((move, promotionKind, attackers))
+        _undoHistory.append((move, promotionKind, self.enPassantTarget, attackers))
         board[piece][move.end] = false
         board[piece][move.start] = true
         playerTurn.invert()
@@ -1054,11 +1054,12 @@ public final class Game {
 
     /// Redoes the previous undone move and returns it, if any.
     private func _redoMove() -> Move? {
-        guard let (move, promotion, attackers) = _undoHistory.popLast() else {
+        guard let (move, promotion, enPassant, attackers) = _undoHistory.popLast() else {
             return nil
         }
         try! _execute(uncheckedMove: move, promotion: { promotion ?? ._queen })
         attackersToKing = attackers
+        enPassantTarget = enPassant
         return move
     }
 


### PR DESCRIPTION
Fixed the bug that a inconsistency may be created by performing
`undoMove()` and `redoMove()` several times.

For example: Let a game starts with the following moves: e2->e4, f7->f5, e4->f5
Then, let's perform `undoMove` and `redoMove`. Then check the available moves for black pawn in g7. An inconsistency may be expected.

Reason: In private function `_redoMove()`, we calls `_execute(uncheckedMove: promotion:)` and passes the move that will be redo. But the property `enPassantMove` has not been updated in `_redoMove`. So there will be an inconsistency in the future calls performed on the game.

Solution: Updates the `enPassantMove ` in `_redoMove()`.